### PR TITLE
Fix kanban drag-and-drop 400 error

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -258,20 +258,13 @@ function handleDrop(event) {
 
 async function updateTaskStatus(taskId, newStatus) {
     try {
-        // First get the current task data
-        const getResponse = await fetch(`/api/tasks/${taskId}`);
-        if (!getResponse.ok) return;
-        
-        const task = await getResponse.json();
-        task.status = newStatus;
-        
-        // Update the task
+        // Update the task with just the new status
         const updateResponse = await fetch(`/api/tasks/${taskId}`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify(task)
+            body: JSON.stringify({ status: newStatus })
         });
 
         if (updateResponse.ok) {


### PR DESCRIPTION
- Fixed updateTask handler to preserve existing task data when updating
- Only update fields that are explicitly provided in the request
- Simplified frontend to send only the status field for status updates
- Maintains backward compatibility and proper error handling

Resolves issue where dragging cards in kanban mode resulted in 400 errors due to task data being overwritten with empty values.