### PR TITLE
fix: Improve task filtering logic in kanban view

### DIFF
--- a/debug_filters.html
+++ b/debug_filters.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Debug Filters</title>
+</head>
+<body>
+    <script>
+        console.log('Saved filters:', localStorage.getItem('projectflow_filters'));
+        
+        // Clear saved filters to test
+        if (localStorage.getItem('projectflow_filters')) {
+            console.log('Clearing saved filters...');
+            localStorage.removeItem('projectflow_filters');
+            console.log('Filters cleared. Reload the main page to test.');
+        } else {
+            console.log('No saved filters found.');
+        }
+    </script>
+    <p>Check console for debugging info. <a href="http://localhost:8081">Go back to main app</a></p>
+</body>
+</html>

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -1055,7 +1055,12 @@ function loadFilterState() {
             setTimeout(() => applyFilters(), 100);
         } catch (error) {
             console.error('Error loading filter state:', error);
+            // Ensure all tasks are visible if filter loading fails
+            setTimeout(() => applyFilters(), 100);
         }
+    } else {
+        // No saved filters, ensure all tasks are visible
+        setTimeout(() => applyFilters(), 100);
     }
 }
 
@@ -1328,6 +1333,17 @@ function applyFilters() {
     
     const taskCards = document.querySelectorAll('.task-card');
     let visibleCount = 0;
+    
+    // If no filters are active, show all tasks
+    const hasActiveFilters = searchTerm || statusFilter || priorityFilter || typeFilter || overdueFilter;
+    if (!hasActiveFilters) {
+        taskCards.forEach(card => {
+            card.style.display = 'block';
+            visibleCount++;
+        });
+        updateFilterResultsCount(visibleCount, taskCards.length);
+        return;
+    }
     
     taskCards.forEach(card => {
         let visible = true;


### PR DESCRIPTION
- Modified applyFilters() to always show all tasks when no filters are active
- Enhanced loadFilterState() to call applyFilters() even with no saved filters
- Added debug HTML file for localStorage filter inspection and clearing
- Ensures all in_progress tasks are visible in kanban column by default

This fixes the issue where tasks with status 'in_progress' were not showing in the kanban column due to saved localStorage filters or initialization issues.