### PR TITLE
Fix view switching - add kanban-view ID and initialize view display

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -32,7 +32,7 @@ class ProjectFlowApp {
         this.dragDropManager = new DragDropManager(this.apiClient, this.stateManager);
         this.uiManager = new UIManager(this.stateManager, this.taskManager);
         this.filterManager = new FilterManager(this.stateManager);
-        this.viewManager = new ViewManager(this.stateManager, this.taskManager, this.projectManager);
+        this.viewManager = new ViewManager();
         
         // Store references globally for compatibility
         window.projectFlowApp = this;

--- a/web/static/js/view-manager.js
+++ b/web/static/js/view-manager.js
@@ -46,8 +46,26 @@ class ViewManager {
             timelineBtn.addEventListener('click', () => this.switchToView('timeline'));
         }
 
-        // Set initial view
+        // Set initial view and ensure proper display state
         this.updateViewButtons();
+        this.initializeViewDisplay();
+    }
+
+    initializeViewDisplay() {
+        // Ensure only the current view is visible on initial load
+        const currentView = stateManager.getCurrentView();
+        const allViews = ['kanban', 'hierarchy', 'timeline'];
+        
+        allViews.forEach(view => {
+            const viewContainer = document.getElementById(`${view}-view`);
+            if (viewContainer) {
+                if (view === currentView) {
+                    viewContainer.style.display = 'block';
+                } else {
+                    viewContainer.style.display = 'none';
+                }
+            }
+        });
     }
 
     switchToView(viewName) {
@@ -325,6 +343,23 @@ class ViewManager {
                 event.preventDefault();
                 const views = ['kanban', 'hierarchy', 'timeline'];
                 this.switchToView(views[parseInt(event.key) - 1]);
+            }
+        });
+    }
+
+    initializeViewDisplay() {
+        // Ensure only the current view is visible on initial load
+        const currentView = stateManager.getCurrentView();
+        const allViews = ['kanban', 'hierarchy', 'timeline'];
+        
+        allViews.forEach(view => {
+            const viewContainer = document.getElementById(`${view}-view`);
+            if (viewContainer) {
+                if (view === currentView) {
+                    viewContainer.style.display = 'block';
+                } else {
+                    viewContainer.style.display = 'none';
+                }
             }
         });
     }

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -123,7 +123,7 @@
             </div>
         </div>
 
-        <div class="task-board">
+        <div id="kanban-view" class="task-board">
             <div class="column" data-status="todo">
                 <h3>To Do</h3>
                 <div class="task-list" id="todo-tasks">


### PR DESCRIPTION
- Added id='kanban-view' to task-board container in HTML template
- Added initializeViewDisplay() method to ViewManager to properly set initial view states
- Fixed ViewManager instantiation in app.js to not pass unnecessary parameters
- Ensures only current view is visible on page load